### PR TITLE
Ticket 1.3: Survey Targeting Evaluation

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@expo/metro-runtime": "~5.0.4",
     "@react-native-async-storage/async-storage": "^2.1.1",
-    "@react-navigation/native": "^6.1.18",
-    "@react-navigation/native-stack": "^6.11.0",
+    "@react-navigation/native": "^7.0.0",
+    "@react-navigation/native-stack": "^7.0.0",
     "expo": "^53.0.8",
     "expo-constants": "~17.1.8",
     "expo-status-bar": "~2.2.3",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,15 +1,21 @@
 import { RootStack } from './RootStack';
 import { NavigationContainer } from '@react-navigation/native';
 import Constants from 'expo-constants';
+import { useRef } from 'react';
 
 import { Usetiful } from 'usetiful-react-native';
 
 export default function App() {
   const USETIFUL_TOKEN = Constants.expoConfig?.extra?.USETIFUL_TOKEN;
+  const navigationRef = useRef(null);
 
   return (
-    <NavigationContainer>
-      <Usetiful token={USETIFUL_TOKEN} tags={{ userId: '2222' }}>
+    <NavigationContainer ref={navigationRef}>
+      <Usetiful
+        token={USETIFUL_TOKEN}
+        tags={{ userId: '2222' }}
+        navigationRef={navigationRef}
+      >
         <RootStack />
       </Usetiful>
     </NavigationContainer>

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "root": true,
     "extends": [
       "@react-native",
-      "prettier"
+      "plugin:prettier/recommended"
     ],
     "rules": {
       "react/react-in-jsx-scope": "off",

--- a/src/Usetiful.tsx
+++ b/src/Usetiful.tsx
@@ -1,4 +1,9 @@
-import { useEffect, useState, type PropsWithChildren } from 'react';
+import {
+  useEffect,
+  useState,
+  type PropsWithChildren,
+  type RefObject,
+} from 'react';
 import { StyleSheet, View } from 'react-native';
 import type { UsetifulTag, Measure } from './types';
 import { useTargeting } from './hooks/useTargeting';
@@ -7,6 +12,7 @@ import { useActiveExperienceStore } from './stores/useActiveExperienceStore';
 import Survey from './Survey';
 import { useDataStore } from './stores/useDataStore';
 import type { Survey as SurveyType } from './types';
+import type { NavigationContainerRef } from '@react-navigation/native';
 import { Tour } from './Tour';
 // TODO remove this once we combine stores
 import { useStore } from './stores/useStore';
@@ -14,9 +20,10 @@ import { useStore } from './stores/useStore';
 type Props = {
   token: string;
   tags?: UsetifulTag;
+  navigationRef?: RefObject<NavigationContainerRef<any>>;
 } & PropsWithChildren;
 
-export const Usetiful = ({ children, token, tags }: Props) => {
+export const Usetiful = ({ children, token, tags, navigationRef }: Props) => {
   // TODO remove this once we combine stores
   const initializeOldStore = useStore((s) => s.initialize);
   const initialize = useDataStore((s) => s.initialize);
@@ -27,7 +34,7 @@ export const Usetiful = ({ children, token, tags }: Props) => {
     // initializeOldStore(token, tags);
   }, [initialize, initializeOldStore, tags, token]);
 
-  useTargeting();
+  useTargeting(navigationRef);
   useProgressorUpdate();
   const [layoutMeasure, setLayoutMeasure] = useState<Measure>();
   const availableTour = useStore((s) => s.availableTour);

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -48,3 +48,8 @@ export const SURVEY_STATE = {
   IN_PROGRESS: 'inProgress',
   CLOSED: 'closed',
 } as const;
+
+export const TARGET_TYPE_ADDRESS_SIMPLE = 'address-simple';
+export const TARGET_TYPE_USER_SEGMENT = 'user-segment';
+export const TARGET_OPERATOR_SEGMENT_EXACT = 'segment-exact';
+export const TARGET_OPERATOR_SEGMENT_IS_NOT = 'segment-is-not';

--- a/src/hooks/useTargeting.ts
+++ b/src/hooks/useTargeting.ts
@@ -1,16 +1,40 @@
-import { useEffect } from 'react';
-import { useCurrentRouteName } from './useCurrentRouteName';
+import { useEffect, useState, type RefObject } from 'react';
 import type { Target } from '../types';
 import { useActiveExperienceStore } from '../stores/useActiveExperienceStore';
 import { useDataStore } from '../stores/useDataStore';
+import type { NavigationContainerRef } from '@react-navigation/native';
+import {
+  TARGET_TYPE_ADDRESS_SIMPLE,
+  TARGET_TYPE_USER_SEGMENT,
+  TARGET_OPERATOR_SEGMENT_IS_NOT,
+} from '../constants';
 
-export const useTargeting = () => {
-  const currentRouteName = useCurrentRouteName();
+export const useTargeting = (
+  navigationRef?: RefObject<NavigationContainerRef<any>>
+) => {
+  const [currentRouteName, setCurrentRouteName] = useState<string>();
   const surveys = useDataStore((s) => s.surveys);
   const setActiveExperience = useActiveExperienceStore(
     (s) => s.setActiveExperience
   );
   const progressorData = useDataStore((s) => s.progressorData);
+
+  useEffect(() => {
+    if (!navigationRef?.current) return;
+
+    const updateRoute = () => {
+      const route = navigationRef.current?.getCurrentRoute();
+      setCurrentRouteName(route?.name);
+    };
+
+    // get initial route
+    updateRoute();
+
+    // Subscribe to future changes
+    const unsubscribe = navigationRef.current.addListener('state', updateRoute);
+
+    return unsubscribe;
+  }, [navigationRef]);
 
   // TODO: reintegrate tours
   // const tours = useStore((s) => s.tours);
@@ -26,15 +50,32 @@ export const useTargeting = () => {
 
       const activeSurveys = surveys
         .filter((survey) => {
+          // Only show surveys with autoplay enabled
+          if (!survey.trigger.autoplay) {
+            return false;
+          }
+
           if (uf_completed.some((completed) => completed.id === survey.id)) {
             return false;
           }
           if (survey.targets.length === 0) {
             return true;
           }
-          return survey.targets.some((target: Target) => {
-            return checkByTargets({ target, path: currentRouteName });
+
+          // Evaluate all targets based on the survey's targetOperator
+          const targetResults = survey.targets.map((target: Target) => {
+            return evaluateTarget(
+              target,
+              currentRouteName,
+              progressorData.autoSegment,
+              progressorData.customSegments
+            );
           });
+
+          // targetOperator: 0 = all conditions must be true, 1 = any condition must be true
+          return survey.targetOperator === 0
+            ? targetResults.every((result) => result)
+            : targetResults.some((result) => result);
         })
         .sort((a, b) => b.objectPriority - a.objectPriority);
 
@@ -54,6 +95,8 @@ export const useTargeting = () => {
     currentRouteName,
     setActiveExperience,
     progressorData.uf_completed,
+    progressorData.autoSegment,
+    progressorData.customSegments,
   ]);
 
   // TODO: reintegrate tours
@@ -111,26 +154,49 @@ export const useTargeting = () => {
   // ]);
 };
 
-const checkByTargets = ({
-  target,
-  path,
-  autoSegment,
-  customSegments,
-}: {
-  target: Target;
-  path?: string;
-  autoSegment?: string;
-  customSegments?: string[];
-}) => {
-  switch (target.type) {
-    case 'user-segment':
-      return (
-        target.formattedName &&
-        (customSegments?.includes(target.formattedName) ||
-          autoSegment === target.formattedName)
-      );
-    case 'address-simple':
-    default:
-      return !!target.url && path?.includes(target.url);
+/**
+ * Recursively evaluates a target or target group against current conditions
+ * @param target - The target to evaluate (can be a simple target or a target group with nested targets)
+ * @param path - Current route/screen name
+ * @param autoSegment - Auto-assigned user segment
+ * @param customSegments - Custom user segments
+ * @returns true if the target matches, false otherwise
+ */
+const evaluateTarget = (
+  target: Target,
+  path?: string,
+  autoSegment?: string,
+  customSegments?: string[]
+): boolean => {
+  // Type guard: Check if this is a TargetGroup (has nested targets)
+  if ('targets' in target) {
+    const nestedResults = target.targets.map((nestedTarget: Target) =>
+      evaluateTarget(nestedTarget, path, autoSegment, customSegments)
+    );
+
+    // Use the target group's own targetOperator
+    return target.targetOperator === 0
+      ? nestedResults.every((result: boolean) => result)
+      : nestedResults.some((result: boolean) => result);
   }
+
+  // Type guard: Handle individual target types based on discriminated union
+  if (target.type === TARGET_TYPE_USER_SEGMENT) {
+    const isInSegment = !!(
+      target.formattedName &&
+      (customSegments?.includes(target.formattedName) ||
+        autoSegment === target.formattedName)
+    );
+
+    return target.operator === TARGET_OPERATOR_SEGMENT_IS_NOT
+      ? !isInSegment
+      : isInSegment;
+  }
+
+  if (target.type === TARGET_TYPE_ADDRESS_SIMPLE) {
+    return !!path && path.includes(target.url);
+  }
+
+  // Fallback for unknown types
+  return false;
 };

--- a/src/hooks/useTargeting.ts
+++ b/src/hooks/useTargeting.ts
@@ -62,7 +62,6 @@ export const useTargeting = (
             return true;
           }
 
-          // Evaluate all targets based on the survey's targetOperator
           const targetResults = survey.targets.map((target: Target) => {
             return evaluateTarget(
               target,
@@ -72,7 +71,6 @@ export const useTargeting = (
             );
           });
 
-          // targetOperator: 0 = all conditions must be true, 1 = any condition must be true
           return survey.targetOperator === 0
             ? targetResults.every((result) => result)
             : targetResults.some((result) => result);
@@ -168,7 +166,6 @@ const evaluateTarget = (
   autoSegment?: string,
   customSegments?: string[]
 ): boolean => {
-  // Type guard: Check if this is a TargetGroup (has nested targets)
   if ('targets' in target) {
     const nestedResults = target.targets.map((nestedTarget: Target) =>
       evaluateTarget(nestedTarget, path, autoSegment, customSegments)
@@ -180,7 +177,6 @@ const evaluateTarget = (
       : nestedResults.some((result: boolean) => result);
   }
 
-  // Type guard: Handle individual target types based on discriminated union
   if (target.type === TARGET_TYPE_USER_SEGMENT) {
     const isInSegment = !!(
       target.formattedName &&

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -84,7 +84,7 @@ export const fetchProgressor = async (
     if (result.tours) {
       try {
         tours = JSON.parse(result.tours);
-      } catch (error) {
+      } catch {
         console.warn("Warning: 'tours' key is not a valid JSON string.");
       }
     } else {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,10 @@
-import { SURVEY_STATE } from '../constants';
-
+import {
+  SURVEY_STATE,
+  TARGET_TYPE_ADDRESS_SIMPLE,
+  TARGET_TYPE_USER_SEGMENT,
+  TARGET_OPERATOR_SEGMENT_EXACT,
+  TARGET_OPERATOR_SEGMENT_IS_NOT,
+} from '../constants';
 export type UsetifulResponse = {
   tours?: Tour[];
   surveys?: Survey[];
@@ -39,12 +44,27 @@ export type TourStep = {
 export type TourTrigger = {
   type: string;
 };
-export type Target = {
-  type: 'address-simple' | 'user-segment' | string;
-  url?: string;
-  formattedName?: string;
-  name?: string;
+
+export type AddressTarget = {
+  type: typeof TARGET_TYPE_ADDRESS_SIMPLE;
+  url: string;
 };
+
+export type UserSegmentTarget = {
+  type: typeof TARGET_TYPE_USER_SEGMENT;
+  operator:
+    | typeof TARGET_OPERATOR_SEGMENT_EXACT
+    | typeof TARGET_OPERATOR_SEGMENT_IS_NOT;
+  name?: string;
+  formattedName?: string;
+};
+
+export type TargetGroup = {
+  targets: Target[];
+  targetOperator: 0 | 1;
+};
+
+export type Target = AddressTarget | UserSegmentTarget | TargetGroup;
 
 export type Measure = {
   x: number;
@@ -169,6 +189,8 @@ export type Survey = {
   pages: SurveyPage[];
   targets: Target[];
   trigger: SurveyTrigger;
+  // 0: all conditions must be true, 1: any condition must be true
+  targetOperator: 0 | 1;
 };
 
 export type SurveyTrigger = AutomaticSurveyTrigger | ManualSurveyTrigger;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3358,35 +3358,63 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-navigation/elements@npm:^1.3.31":
-  version: 1.3.31
-  resolution: "@react-navigation/elements@npm:1.3.31"
-  peerDependencies:
-    "@react-navigation/native": ^6.0.0
-    react: "*"
-    react-native: "*"
-    react-native-safe-area-context: ">= 3.0.0"
-  checksum: 1e4a65ccd9fab757d01bf41f605aafd6ca8301ae25ad7d3f1769320793418cca9fe2f25ac9337578ce1e0a1560bbbc3a88f18b899867aacd4d31de7a789e417e
-  languageName: node
-  linkType: hard
-
-"@react-navigation/native-stack@npm:^6.11.0":
-  version: 6.11.0
-  resolution: "@react-navigation/native-stack@npm:6.11.0"
+"@react-navigation/core@npm:^7.14.0":
+  version: 7.14.0
+  resolution: "@react-navigation/core@npm:7.14.0"
   dependencies:
-    "@react-navigation/elements": ^1.3.31
-    warn-once: ^0.1.0
+    "@react-navigation/routers": ^7.5.3
+    escape-string-regexp: ^4.0.0
+    fast-deep-equal: ^3.1.3
+    nanoid: ^3.3.11
+    query-string: ^7.1.3
+    react-is: ^19.1.0
+    use-latest-callback: ^0.2.4
+    use-sync-external-store: ^1.5.0
   peerDependencies:
-    "@react-navigation/native": ^6.0.0
-    react: "*"
-    react-native: "*"
-    react-native-safe-area-context: ">= 3.0.0"
-    react-native-screens: ">= 3.0.0"
-  checksum: d3dd57c216f5dbe53636bdb9aa48fe27831640f868cf5c68731943a49b68cb457d81182e7868f3e3033da0564e9f193f1b06b69085b8bc5b04ccfbe12ea2bbc0
+    react: ">= 18.2.0"
+  checksum: e61b5dded9efd888f2f25aca0454cff1f0286bf893f6d6d677bb31f2267cdcdd96f691d0b61673eca03512502024dfc786a41f48e434b83b2a2769e2578b76a8
   languageName: node
   linkType: hard
 
-"@react-navigation/native@npm:^6.0.0, @react-navigation/native@npm:^6.1.18":
+"@react-navigation/elements@npm:^2.9.5":
+  version: 2.9.5
+  resolution: "@react-navigation/elements@npm:2.9.5"
+  dependencies:
+    color: ^4.2.3
+    use-latest-callback: ^0.2.4
+    use-sync-external-store: ^1.5.0
+  peerDependencies:
+    "@react-native-masked-view/masked-view": ">= 0.2.0"
+    "@react-navigation/native": ^7.1.28
+    react: ">= 18.2.0"
+    react-native: "*"
+    react-native-safe-area-context: ">= 4.0.0"
+  peerDependenciesMeta:
+    "@react-native-masked-view/masked-view":
+      optional: true
+  checksum: 05756cea0510d5d3058edb6da60b44ae6d029f50da90ed4a6405ebfcea534fa838a359bab183377036f33616b08998e23edc6974a5796d5e07678e45a9c9b514
+  languageName: node
+  linkType: hard
+
+"@react-navigation/native-stack@npm:^7.0.0":
+  version: 7.11.0
+  resolution: "@react-navigation/native-stack@npm:7.11.0"
+  dependencies:
+    "@react-navigation/elements": ^2.9.5
+    color: ^4.2.3
+    sf-symbols-typescript: ^2.1.0
+    warn-once: ^0.1.1
+  peerDependencies:
+    "@react-navigation/native": ^7.1.28
+    react: ">= 18.2.0"
+    react-native: "*"
+    react-native-safe-area-context: ">= 4.0.0"
+    react-native-screens: ">= 4.0.0"
+  checksum: 08c5672cad896dbc71d3640db18a624e5b1a240619d9936b0b270d2b757a6b449293fa03af33229ee80f64abb2426d2c7fb0ef8c91b401721630d2dbd2b92080
+  languageName: node
+  linkType: hard
+
+"@react-navigation/native@npm:^6.0.0":
   version: 6.1.18
   resolution: "@react-navigation/native@npm:6.1.18"
   dependencies:
@@ -3401,12 +3429,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-navigation/native@npm:^7.0.0":
+  version: 7.1.28
+  resolution: "@react-navigation/native@npm:7.1.28"
+  dependencies:
+    "@react-navigation/core": ^7.14.0
+    escape-string-regexp: ^4.0.0
+    fast-deep-equal: ^3.1.3
+    nanoid: ^3.3.11
+    use-latest-callback: ^0.2.4
+  peerDependencies:
+    react: ">= 18.2.0"
+    react-native: "*"
+  checksum: 7950a3b2a0cb712b12f52c9df3ffed8ebd317843a875b0ec764fff52922f2c51754759b8c866a9a36c02ec8c00c4be6604b1350e5546e3c83041b6372c9aef80
+  languageName: node
+  linkType: hard
+
 "@react-navigation/routers@npm:^6.1.9":
   version: 6.1.9
   resolution: "@react-navigation/routers@npm:6.1.9"
   dependencies:
     nanoid: ^3.1.23
   checksum: 3a3392ce095d6a2bd2aad69856f513b35774f943a3dc73d8ffb75127de6773203e3264188d87058bdea4c0c9a7d43ed28d0cbf3a1f1cdc086df3ee255d8e1e27
+  languageName: node
+  linkType: hard
+
+"@react-navigation/routers@npm:^7.5.3":
+  version: 7.5.3
+  resolution: "@react-navigation/routers@npm:7.5.3"
+  dependencies:
+    nanoid: ^3.3.11
+  checksum: 1b8397ade6bbab51a60d2671fd88eca2e0cf22b9cd10bee16d3537bc5f05deea7dad8c116a809f580c87c5a6cceae7c4fc9f20644f45076ee8f00524e903fc4b
   languageName: node
   linkType: hard
 
@@ -4983,10 +5036,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-name@npm:~1.1.4":
+"color-name@npm:^1.0.0, color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: b0445859521eb4021cd0fb0cc1a75cecf67fceecae89b63f62b201cca8d345baf8b952c966862a9d9a2632987d4f6581f0ec8d957dfacece86f0a7919316f610
+  languageName: node
+  linkType: hard
+
+"color-string@npm:^1.9.0":
+  version: 1.9.1
+  resolution: "color-string@npm:1.9.1"
+  dependencies:
+    color-name: ^1.0.0
+    simple-swizzle: ^0.2.2
+  checksum: c13fe7cff7885f603f49105827d621ce87f4571d78ba28ef4a3f1a104304748f620615e6bf065ecd2145d0d9dad83a3553f52bb25ede7239d18e9f81622f1cc5
+  languageName: node
+  linkType: hard
+
+"color@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "color@npm:4.2.3"
+  dependencies:
+    color-convert: ^2.0.1
+    color-string: ^1.9.0
+  checksum: 0579629c02c631b426780038da929cca8e8d80a40158b09811a0112a107c62e10e4aad719843b791b1e658ab4e800558f2e87ca4522c8b32349d497ecb6adeb4
   languageName: node
   linkType: hard
 
@@ -8020,6 +8093,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-arrayish@npm:^0.3.1":
+  version: 0.3.4
+  resolution: "is-arrayish@npm:0.3.4"
+  checksum: 09816634eb7b6e357067f6b49c7656b4aff6d8b25486553d086bab53ce0f929c0293906539503b2a317f3137b5a5cd7e9ea01305f6090c0037c4340d9121420d
+  languageName: node
+  linkType: hard
+
 "is-async-function@npm:^2.0.0":
   version: 2.1.1
   resolution: "is-async-function@npm:2.1.1"
@@ -10561,6 +10641,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^3.3.11":
+  version: 3.3.11
+  resolution: "nanoid@npm:3.3.11"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 3be20d8866a57a6b6d218e82549711c8352ed969f9ab3c45379da28f405363ad4c9aeb0b39e9abc101a529ca65a72ff9502b00bf74a912c4b64a9d62dfd26c29
+  languageName: node
+  linkType: hard
+
 "natural-compare-lite@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare-lite@npm:1.4.0"
@@ -11780,6 +11869,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-is@npm:^19.1.0":
+  version: 19.2.4
+  resolution: "react-is@npm:19.2.4"
+  checksum: 646d4f0f11b50131f3f7ac5b50d12b79de35be20fa84bce33fd3fc91557589e388562cb6203b5237098fd983cd1cdf12c5fb952b7f9903ac014de9a5a6cc7e28
+  languageName: node
+  linkType: hard
+
 "react-native-builder-bob@npm:^0.29.0":
   version: 0.29.1
   resolution: "react-native-builder-bob@npm:0.29.1"
@@ -12740,6 +12836,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sf-symbols-typescript@npm:^2.1.0":
+  version: 2.2.0
+  resolution: "sf-symbols-typescript@npm:2.2.0"
+  checksum: e380b37afec5dbc9f3aced06c6e82ebe13d1bc25a3d5966fc52bcfa891cb56951dabbe8a98fc4d96ef86b2c556b23cf9686fc17df6c4aa1ec839f92ae280486c
+  languageName: node
+  linkType: hard
+
 "shebang-command@npm:^2.0.0":
   version: 2.0.0
   resolution: "shebang-command@npm:2.0.0"
@@ -12846,6 +12949,15 @@ __metadata:
     bplist-parser: 0.3.2
     plist: ^3.0.5
   checksum: fa8086f6b781c289f1abad21306481dda4af6373b32a5d998a70e53c2b7218a1d21ebb5ae3e736baae704c21d311d3d39d01d0e6a2387eda01b4020b9ebd909e
+  languageName: node
+  linkType: hard
+
+"simple-swizzle@npm:^0.2.2":
+  version: 0.2.4
+  resolution: "simple-swizzle@npm:0.2.4"
+  dependencies:
+    is-arrayish: ^0.3.1
+  checksum: 9a2f6f39a6b9fab68f96903523bf19953ec21e5e843108154cf47a9cc0f78955dd44f64499ffb71a849ac10c758d9fab7533627c7ca3ab40b5c177117acfdc1b
   languageName: node
   linkType: hard
 
@@ -14030,12 +14142,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"use-latest-callback@npm:^0.2.4":
+  version: 0.2.6
+  resolution: "use-latest-callback@npm:0.2.6"
+  peerDependencies:
+    react: ">=16.8"
+  checksum: 67a245bf91b23ef0d2d2c8a52845da62e006867bd9d93a99ca4d2f859101fcd54c7afd4f5a3b8bb5d24283f516e7e41bd8226250ee39affc33bd1cfd622a5cfb
+  languageName: node
+  linkType: hard
+
 "use-sync-external-store@npm:^1.2.2":
   version: 1.4.0
   resolution: "use-sync-external-store@npm:1.4.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: dc3843a1b59ac8bd01417bd79498d4c688d5df8bf4801be50008ef4bfaacb349058c0b1605b5b43c828e0a2d62722d7e861573b3f31cea77a7f23e8b0fc2f7e3
+  languageName: node
+  linkType: hard
+
+"use-sync-external-store@npm:^1.5.0":
+  version: 1.6.0
+  resolution: "use-sync-external-store@npm:1.6.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 61a62e910713adfaf91bdb72ff2cd30e5ba83687accaf3b6e75a903b45bf635f5722e3694af30d83a03e92cb533c0a5c699298d2fef639a03ffc86b469f4eee2
   languageName: node
   linkType: hard
 
@@ -14046,8 +14176,8 @@ __metadata:
     "@babel/core": ^7.20.0
     "@expo/metro-runtime": ~5.0.4
     "@react-native-async-storage/async-storage": ^2.1.1
-    "@react-navigation/native": ^6.1.18
-    "@react-navigation/native-stack": ^6.11.0
+    "@react-navigation/native": ^7.0.0
+    "@react-navigation/native-stack": ^7.0.0
     expo: ^53.0.8
     expo-constants: ~17.1.8
     expo-status-bar: ~2.2.3
@@ -14179,7 +14309,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"warn-once@npm:^0.1.0":
+"warn-once@npm:^0.1.0, warn-once@npm:^0.1.1":
   version: 0.1.1
   resolution: "warn-once@npm:0.1.1"
   checksum: e6a5a1f5a8dba7744399743d3cfb571db4c3947897875d4962a7c5b1bf2195ab4518c838cb4cea652e71729f21bba2e98dc75686f5fccde0fabbd894e2ed0c0d


### PR DESCRIPTION
### Overview

## Changing route detection API
There's a bug in the current `useCurrentRouteName` hook, where the first screen the user lands on will not be reported. This has to do with how our `Usetiful` wrapper is outside the Root Stack and based on how `useNavigationState` is written in the library, so I could not find a way around this.

The new API will require users to pass in a `navigationRef`, which we will then set a manual route listener ourselves. The current logic is in `useTargeting.ts`

Tested on React Navigation v6 and v7.

## Supporting condition groups

The current implementation was tested with settings: 

<img width="1111" height="495" alt="O Only certain poges and user segments" src="https://github.com/user-attachments/assets/5fcd07d5-98a9-45d2-865f-2936c13f7cac" />

## Additional features added: 

* Added support for target operators `AND || OR`
* Retained support for "user segments" and "URL contains"