### PR TITLE
feat: send G&S events to fullstory

### DIFF
--- a/src/Survey.tsx
+++ b/src/Survey.tsx
@@ -11,6 +11,11 @@ import {
   updateSurveyCompleted,
 } from './stores/util/surveyProgress';
 import { saveSurveyAnswer } from './stores/util/surveyAnswers';
+import {
+  fsTrackSurveyStateChanged,
+  fsTrackSurveyPageSeen,
+  fsTrackQuestionAnswered,
+} from './utils/fsEvents';
 import { useActiveExperienceStore } from './stores/useActiveExperienceStore';
 import { useDataStore } from './stores/useDataStore';
 
@@ -51,7 +56,17 @@ const Survey = ({ survey }: { survey: SurveyType }) => {
     }
 
     updateSurveyStarted(survey.id, survey.name, firstPage.id);
-  }, [survey.id, survey.name, survey.pages, surveyProgress]);
+    fsTrackSurveyStateChanged(survey, firstPage, 0, 'started');
+  }, [survey, surveyProgress]);
+
+  // Fire "Survey Page Seen" when showing any page
+  useEffect(() => {
+    if (!currentPage) {
+      return;
+    }
+
+    fsTrackSurveyPageSeen(survey, currentPage, currentPageIndex);
+  }, [survey, currentPage, currentPageIndex]);
 
   // Filter to only supported question types
   const supportedQuestions =
@@ -64,17 +79,29 @@ const Survey = ({ survey }: { survey: SurveyType }) => {
       return;
     }
 
-    // Save each answer
+    // Save each answer and fire FullStory "Question Answered"
     Object.entries(data).forEach(([questionId, value]) => {
       const question = supportedQuestions.find((q) => q.id === questionId);
       if (question && value !== undefined && value !== null && value !== '') {
+        const answer = value as string | number;
         saveSurveyAnswer(
           survey.id,
           questionId,
           question.type,
-          value as string | number,
+          answer,
           currentPage.id,
           currentPage.name
+        );
+        const questionIndex = currentPage.questions.findIndex(
+          (q) => q.id === questionId
+        );
+        fsTrackQuestionAnswered(
+          survey,
+          currentPage,
+          currentPageIndex,
+          question,
+          questionIndex >= 0 ? questionIndex : 0,
+          answer
         );
       }
     });
@@ -86,6 +113,12 @@ const Survey = ({ survey }: { survey: SurveyType }) => {
       updateSurveyProgress(survey.id, nextPage.id);
     } else {
       updateSurveyCompleted(survey.id);
+      fsTrackSurveyStateChanged(
+        survey,
+        currentPage,
+        currentPageIndex,
+        'completed'
+      );
     }
   };
 
@@ -99,11 +132,17 @@ const Survey = ({ survey }: { survey: SurveyType }) => {
   return (
     <View style={styles.container}>
       <View style={styles.modal}>
-        {currentPage.actions.close && (
+        {currentPage.closeButton && (
           <View style={styles.modalHeader}>
             <CrossBtn
               onClose={() => {
                 updateSurveyClosed(survey.id);
+                fsTrackSurveyStateChanged(
+                  survey,
+                  currentPage,
+                  currentPageIndex,
+                  'closed'
+                );
                 setSelfClosed(true);
               }}
             />

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -53,3 +53,9 @@ export const TARGET_TYPE_ADDRESS_SIMPLE = 'address-simple';
 export const TARGET_TYPE_USER_SEGMENT = 'user-segment';
 export const TARGET_OPERATOR_SEGMENT_EXACT = 'segment-exact';
 export const TARGET_OPERATOR_SEGMENT_IS_NOT = 'segment-is-not';
+
+export const FS_EVENT_NAMES = {
+  surveyStateChanged: 'Survey State Changed',
+  surveyPageSeen: 'Survey Page Seen',
+  questionAnswered: 'Question Answered',
+} as const;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -191,6 +191,7 @@ export type SurveyPage = {
   customStyle: any;
   actions: SurveyAction;
   questions: SurveyQuestion[];
+  closeButton: boolean;
 };
 
 export type SurveyAction = {

--- a/src/utils/fsEvents.ts
+++ b/src/utils/fsEvents.ts
@@ -76,7 +76,7 @@ export function fsTrackQuestionAnswered(
     props.npsCategory = npsCategory(answer);
   }
   if (question.type === 'open') {
-    props.answer = 'MASKED';
+    props.answer = 'answer masked';
   }
   Fullstory.event(FS_EVENT_NAMES.questionAnswered, props);
 }

--- a/src/utils/fsEvents.ts
+++ b/src/utils/fsEvents.ts
@@ -1,0 +1,82 @@
+import Fullstory from '@fullstory/react-native';
+import type { Survey, SurveyPage, SurveyQuestion } from '../types';
+import { FS_EVENT_NAMES } from '../constants';
+
+function baseSurveyPageProperties(
+  survey: Survey,
+  page: SurveyPage,
+  pageIndex: number
+): Record<string, string | number> {
+  return {
+    surveyName: survey.name,
+    surveyId: survey.id,
+    pageName: page.name,
+    pageType: page.type,
+    pageId: page.id,
+    pageIndex,
+  };
+}
+
+/**
+ * Fire "Survey State Changed" (started or completed).
+ */
+export function fsTrackSurveyStateChanged(
+  survey: Survey,
+  page: SurveyPage,
+  pageIndex: number,
+  state: 'started' | 'completed' | 'closed'
+): void {
+  Fullstory.event(FS_EVENT_NAMES.surveyStateChanged, {
+    ...baseSurveyPageProperties(survey, page, pageIndex),
+    state,
+  });
+}
+
+/**
+ * Fire "Survey Page Seen" when a page is shown.
+ */
+export function fsTrackSurveyPageSeen(
+  survey: Survey,
+  page: SurveyPage,
+  pageIndex: number
+): void {
+  Fullstory.event(FS_EVENT_NAMES.surveyPageSeen, {
+    ...baseSurveyPageProperties(survey, page, pageIndex),
+  });
+}
+
+const npsCategory = (score: number): 'promoter' | 'neutral' | 'detractor' => {
+  if (score >= 9) return 'promoter';
+  if (score >= 7) return 'neutral';
+  return 'detractor';
+};
+
+/**
+ * Fire "Question Answered" for each submitted question.
+ * For NPS questions, adds npsCategory. Open answers are masked.
+ */
+export function fsTrackQuestionAnswered(
+  survey: Survey,
+  page: SurveyPage,
+  pageIndex: number,
+  question: SurveyQuestion,
+  questionIndex: number,
+  answer: string | number
+): void {
+  const props: Record<string, string | number | boolean> = {
+    ...baseSurveyPageProperties(survey, page, pageIndex),
+    questionName: question.question,
+    questionId: question.id,
+    questionType: question.type,
+    isRequired: question.required,
+    questionIndex,
+    answer,
+  };
+  if (question.type === 'nps' && typeof answer === 'number') {
+    props.npsCategory = npsCategory(answer);
+  }
+  if (question.type === 'open') {
+    props.answer = 'MASKED';
+  }
+  Fullstory.event(FS_EVENT_NAMES.questionAnswered, props);
+}


### PR DESCRIPTION
## Summary

**Send G&S events to Fullstory**

Things to note:
* Survey state `'started'` will only be sent on the first time a survey is started, meaning that there isn't progressor data on for that survey
* Survey page seen is fired for **every** survey page. I believe on web it's not fired for the first page. We can discuss whether this is an explicit design choice or unintended.
* `guides_and_surveys` capture source data is unsupported by mobile 

Sample session:
https://app.onfire.fyi/ui/o-1Y9Z-na1/session/5965952571277312:7386884294664964551